### PR TITLE
Removes the preamble from the table of contents

### DIFF
--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -1,7 +1,6 @@
 - title: Getting started
   docs:
     - Abstract
-    - Preamble
     - Introduction
   subs:
     Components:


### PR DESCRIPTION
The preamble was removed, so it should be removed from the table of contents