### PR TITLE
Remove id column and use name is primary key

### DIFF
--- a/_docs/Qabel-Protocol-Box.md
+++ b/_docs/Qabel-Protocol-Box.md
@@ -539,9 +539,8 @@ Table of all file objects in the directory
 */
 CREATE TABLE files
 (
-       id               INTEGER PRIMARY KEY,
-       block              VARCHAR(255) NOT NULL,
-       name             VARCHAR(255) NOT NULL,
+       block            VARCHAR(255) NOT NULL,
+       name             VARCHAR(255) PRIMARY KEY,
        size             LONG NOT NULL,
        mtime            LONG NOT NULL,
        key              BLOB NOT NULL
@@ -556,9 +555,8 @@ Table of all folder objects in the directory
 */
 CREATE TABLE folders
 (
-       id               INTEGER PRIMARY KEY,
        ref              VARCHAR(255) NOT NULL,
-       name             VARCHAR(255) NOT NULL,
+       name             VARCHAR(255) PRIMARY KEY,
        key              BLOB NOT NULL
 );
 
@@ -572,9 +570,8 @@ Table of all external objects in the directory
 */
 CREATE TABLE externals
 (
-       id              INTEGER PRIMARY KEY,
        owner           BLOB NOT NULL,
-       name            VARCHAR(255) NOT NULL,
+       name            VARCHAR(255) PRIMARY KEY,
        key             BLOB NOT NULL,
        url             TEXT NOT NULL
 );


### PR DESCRIPTION
There is no need for an additional id field. The name coloumn already
should have been specified as UNIQUE, so we might as well use it as the
PRIMARY KEY.

These changes are already merged in qabel-android and are in the PR for qabel-deskop: https://github.com/Qabel/qabel-desktop/pull/35