### PR TITLE
Extended identity and contact by email and phone (both optional)

### DIFF
--- a/_docs/Qabel-Client-Configuration.md
+++ b/_docs/Qabel-Client-Configuration.md
@@ -143,6 +143,8 @@ Summary
 | id | Unique identifier |
 | updated, created, deleted | timestamp in [seconds since epoc](http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap04.html#tag_04_15) |
 | alias | Textual, user-defined label identifying this identity (also to other users) |
+| email | Email address of the user owning this identity (optional) |
+| phone | Phone number of the user owning this identity (optional) |
 | private_key | Private, secret part of the key pair |
 | public_key | Public part of the key pair |
 | drops | List of [urls](../Qabel-Protocol-Drop#url) of the drops where the identity expects to receive messages |
@@ -156,6 +158,8 @@ Summary
                         'created': LONG,
                         'deleted': LONG,
                         'alias' : NAME,
+                        'email': STR,
+                        'phone': STR,
                         'keys' :
                                 "{"
                                 'private_key' : KEY,

--- a/_docs/Qabel-Client-Contact-Drop-Messages.md
+++ b/_docs/Qabel-Client-Contact-Drop-Messages.md
@@ -31,6 +31,8 @@ The following items define a contact item:
 * id (unique identifier)
 * updated, created, deleted (timestamp in [seconds since epoc](http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap04.html#tag_04_15) |
 * alias (alias for the contact)
+* email (email address for the contact, optional)
+* phone (phone number for the contact, optional)
 * public_key (public key of the contact)
 * my_identity ([key id](../Components-Crypto#key-identifier/) of the public key of the identity which owns this contact)
 * drop_urls (array of drop urls)
@@ -43,7 +45,9 @@ Summary
                     'updated': LONG,
                     'created': LONG,
                     'deleted': LONG,
-                    'alias': STR,	
+                    'alias': NAME,
+                    'email': STR,
+                    'phone': STR,
                     'keys' :
                              "{"
                              'public_key' : KEY,
@@ -62,6 +66,8 @@ Summary
   "created": 1422605430969,
   "deleted": 0,
   "alias": "Alice",
+  "email": "alice@example.org",
+  "phone": "+49123456789012",
   "public_key" : "feffe9928665731c6d6a8f9467308308feffe9928665731c6d6a8f9467308308",
   "my_identity" : "8520f0098930a754748b7ddcb43ef75a0dbf3a0d26381af4eba4a98eaa9b4e6a",
   "drop_urls" : ["example.org/jkl"],


### PR DESCRIPTION
Email address and phone number should be (optionally) displayed while searching a contact on the register server. Thus, they should exist in the identity from which the contact is extracted before uploading.

Related to Qabel/qabel-desktop#56